### PR TITLE
Support WSO2 redirect format with HTML5 mode enabled

### DIFF
--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -71,7 +71,14 @@
 			$window.sessionStorage.setItem('verifyState', null);
 
 			if ($location.$$html5) {
-				if ($location.path().length > 1) {
+				var hashValues = $location.hash();
+				if (hashValues.length > 0) {
+					service.token = setTokenFromHashParams(hashValues);
+					if (service.token) {
+						parsedFromHash = true;
+					}
+				}
+				else if ($location.path().length > 1) {
 					var values = $location.path().substring(1);
 					service.token = setTokenFromHashParams(values);
 					if (service.token) {

--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -232,7 +232,7 @@
 	}]);
 
 	// Open ID directive
-	angular.module('oauth2.directive', ['angular-md5']).directive('oauth2', ['$rootScope', '$http', '$window', '$location', '$templateCache', '$compile', 'AccessToken', 'Endpoint', 'md5', function($rootScope, $http, $window, $location, $templateCache, $compile, accessToken, endpoint, md5) {
+	angular.module('oauth2.directive', ['angular-md5']).directive('oauth2', ['$injector', '$rootScope', '$http', '$window', '$location', '$templateCache', '$compile', 'AccessToken', 'Endpoint', 'md5', function($injector, $rootScope, $http, $window, $location, $templateCache, $compile, accessToken, endpoint, md5) {
 		var definition = {
 		    restrict: 'E',
 		    replace: true,
@@ -278,11 +278,12 @@
 	            }
 		    };
 
-			function stateChangeHandler(event, nextRoute) {
-				if (nextRoute && nextRoute.requireToken) {
+			function stateChangeHandler(event, toState, toParams, fromState, fromParams) {
+				if (toState && toState.requireToken) {
 					if (!accessToken.get()) {
-						event.preventDefault();
-						$window.sessionStorage.setItem('oauthRedirectRoute', $location.path());
+						var $state = $injector.get('$state');
+						var locationPath = $state.href(toState, toParams, {absolute: false});
+						$window.sessionStorage.setItem('oauthRedirectRoute', locationPath);
 						endpoint.authorize();
 					}
 				}

--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -278,6 +278,16 @@
 	            }
 		    };
 
+			function stateChangeHandler(event, nextRoute) {
+				if (nextRoute && nextRoute.requireToken) {
+					if (!accessToken.get()) {
+						event.preventDefault();
+						$window.sessionStorage.setItem('oauthRedirectRoute', $location.path());
+						endpoint.authorize();
+					}
+				}
+			};
+
 		    function generateState() {
 				var text = ((Date.now() + Math.random()) * Math.random()).toString().replace(".","");
 				return md5.createHash(text);
@@ -310,6 +320,7 @@
 					scope.signedIn = false;
 				});
 				$rootScope.$on('$routeChangeStart', routeChangeHandler);
+				$rootScope.$on('$stateChangeStart', stateChangeHandler);
 			}
 
 			scope.$watch('clientId', function(value) { init(); });


### PR DESCRIPTION
Hi,

I am using WSO2 API Manager as my Identity Provider and after the authorization is done, WSO2 makes a redirect with the following format:

http://localhost:3000/public#access_token=...&state=...&expires_in=...

When you check if HTML5 mode is enabled, I added code to verify first if there is any hash in the url and handle it if it exists, in the other case I let the code that was already there.
