### PR TITLE
Checks the oauthRedirectRoute is not string 'null' before attempting …

### DIFF
--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -109,7 +109,7 @@
 				if (!parsedFromHash || previousState == service.token.state) {
 					$rootScope.$broadcast('oauth2:authSuccess');
 					var oauthRedirectRoute = $window.sessionStorage.getItem('oauthRedirectRoute');
-					if (oauthRedirectRoute) {
+					if (oauthRedirectRoute && oauthRedirectRoute != "null") {
 						$window.sessionStorage.setItem('oauthRedirectRoute', null);
 						$location.path(oauthRedirectRoute);
 					}


### PR DESCRIPTION
…redirect

When setting oauthRedirectRoute to null and retrieving it from sessionStorage it is returned as string 'null'. This is tested for in the scenario where it might need to redirect.
