### PR TITLE
Reject response on error

### DIFF
--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -175,7 +175,7 @@
 	  			else if (response.status === 500) {
 	  				$rootScope.$broadcast('oauth2:internalservererror');
 	  			}
-	  			return response;
+	  			return $q.reject(response);
 	  		}
 		};
 	  	return service;


### PR DESCRIPTION
The correct way to close a response error handler is to reject the response, not simply return it, or anything using the plugin won't be able to use the error handler clause with their promises.
