### PR TITLE
Handle secure login on the '/' path

### DIFF
--- a/dist/angularJsOAuth2.js
+++ b/dist/angularJsOAuth2.js
@@ -111,7 +111,7 @@
 				if (!parsedFromHash || previousState == service.token.state) {
 					$rootScope.$broadcast('oauth2:authSuccess', service.token);
 					var oauthRedirectRoute = $window.sessionStorage.getItem('oauthRedirectRoute');
-					if (oauthRedirectRoute && oauthRedirectRoute != "null") {
+					if (typeof(oauthRedirectRoute) !== 'undefined' && oauthRedirectRoute != "null") {
 						$window.sessionStorage.setItem('oauthRedirectRoute', null);
 						$location.path(oauthRedirectRoute);
 					}


### PR DESCRIPTION
It seems that for the case where the route is '/' the redirect that clears the uri hashes does not fire, 

I believe this is because the 'oauthRedirectRoute' value stored in sessionStorage is an empty string in this case
which resolves to a truthy false.
