### PR TITLE
Reintegrate global functions and format code

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-OAuth2",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://github.com/JamesRandall/AngularJS-OAuth2",
   "authors": [
     "James Randall"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "AngularJS-OAuth2",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "homepage": "https://github.com/JamesRandall/AngularJS-OAuth2",
   "authors": [
     "James Randall"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-oauth2",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Bower and npm package for allowing an AngularJS application to authenticate with an OAuth 2 / Open ID Connect identity provider using the implicit flow.",
   "main": "dist/angularJsOAuth2.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-oauth2",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Bower and npm package for allowing an AngularJS application to authenticate with an OAuth 2 / Open ID Connect identity provider using the implicit flow.",
   "main": "dist/angularJsOAuth2.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,15 +28,17 @@
   "homepage": "https://github.com/JamesRandall/AngularJS-OAuth2",
   "devDependencies": {
     "grunt": "^0.4.5",
-    "karma-script-launcher": "^0.1.0",
+    "grunt-cli": "^0.1.13",
+    "grunt-karma": "^0.11.1",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.12.37",
     "karma-chrome-launcher": "^0.2.0",
     "karma-jasmine": "^0.3.5",
     "karma-phantomjs-launcher": "^0.2.0",
-    "karma": "^0.12.37",
+    "karma-sauce-launcher": "~0.1.8",
+    "karma-script-launcher": "^0.1.0",
     "karma-story-reporter": "^0.3.1",
-    "grunt-karma": "^0.11.1",
-    "grunt-cli": "^0.1.13",
-    "karma-sauce-launcher": "~0.1.8"
+    "phantomjs": "^2.1.7"
   },
   "dependencies": {
     "angular-md5": "^0.1.10"


### PR DESCRIPTION
First of: thanks for your work james!

I've reintegrated the global functions `expired` (renamed to `isExpired`) and `getSessionToken` into the `AccessToken` factory and made the `tokenStorage` an object of the factory as well.

The background is that I'm using the services without the directive and I needed a different token storage. 

Further on there were two missing node modules for the unit tests and I let my IDE reformat the code to a consistent code style.
